### PR TITLE
feat: add interactive network visualization

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,8 +20,8 @@ import getpass
 import socket
 
 
-from modelo_red import calcular_riesgo_red_auto  # <- tu función tal cual
-from modelo_red import filtrar_tipo_sin_ros_y_podar_descendientes 
+from modelo_red import calcular_riesgo_red_auto, draw_state_to_json  # <- funciones principales
+from modelo_red import filtrar_tipo_sin_ros_y_podar_descendientes
 # --- arriba del todo, variables globales ---
 
 
@@ -632,7 +632,9 @@ class Api:
             # 3) Serializar la figura a PNG base64      
             
             png_b64 = img_base64
-    
+
+            graph_json = draw_state_to_json(draw_state)
+
             # 4) Serializar tabla (solo columnas clave)
             col_rank = "Riesgo Ajustado" if ("Riesgo Ajustado" in df_aportes.columns) else "Riesgo Ajustado"
            
@@ -644,7 +646,8 @@ class Api:
                 "ok": True,
                 "png_b64": png_b64,
                 "tabla": tabla_json,
-                "meta": meta
+                "meta": meta,
+                "graph": graph_json
             }
         
         except Exception as e:

--- a/modelo_red.py
+++ b/modelo_red.py
@@ -1335,3 +1335,41 @@ def render_png_from_state(draw_state: dict,
     out = base64.b64encode(buf.getvalue()).decode("ascii")
     plt.close(fig)
     return out
+
+
+def draw_state_to_json(draw_state: dict) -> dict:
+    """Convierte el snapshot de dibujo en listas JSON de nodos y aristas."""
+    if not isinstance(draw_state, dict):
+        return {"nodes": [], "edges": []}
+
+    metric_map = {str(k): float(v) for k, v in (draw_state.get("metric_map") or {}).items()}
+    riesgo_set = set(str(x) for x in (draw_state.get("riesgo_set") or []))
+    patrimonio_set = set(str(x) for x in (draw_state.get("patrimonio_set") or []))
+    conc_set = set(str(x) for x in (draw_state.get("concentracion_set") or []))
+    pos_map = {str(k): v for k, v in (draw_state.get("pos_full") or {}).items()}
+
+    nodes = []
+    for nid in draw_state.get("nodes_full", []):
+        nid = str(nid)
+        pos = pos_map.get(nid, (None, None))
+        x = pos[0] if isinstance(pos, (list, tuple)) else None
+        y = pos[1] if isinstance(pos, (list, tuple)) and len(pos) > 1 else None
+        nodes.append({
+            "id": nid,
+            "riesgo": metric_map.get(nid, 0.0),
+            "es_riesgo": nid in riesgo_set,
+            "es_patrimonio": nid in patrimonio_set,
+            "es_concentracion": nid in conc_set,
+            "x": x,
+            "y": y,
+        })
+
+    edges = []
+    for e in draw_state.get("edges_full", []):
+        edges.append({
+            "u": str(e.get("u")),
+            "v": str(e.get("v")),
+            "tipo": e.get("tipo", "")
+        })
+
+    return {"nodes": nodes, "edges": edges}

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Red de riesgo - Área de Inteligencia Estratégica</title>
+  <link rel="stylesheet" href="https://unpkg.com/vis-network/styles/vis-network.css" />
+  <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
   <style>
     body {
       font-family: system-ui, sans-serif;
@@ -170,14 +172,18 @@
     }
 
     /* Imagen centrada (oculta hasta tener data) */
-    #img {
-      max-width: none;           /* el scale controla el tamaño */
-      user-select: none;
-      pointer-events: auto;
-      cursor: grab;
-      display: none;             /* inicia oculta */
-      transform-origin: center center;
-      image-rendering: auto;
+    #network {
+      width: 100%;
+      height: 100%;
+    }
+    #nodeInfo {
+      display: none;
+      margin-top: 8px;
+      padding: 6px;
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 12px;
     }
 
     /* Botón descargar */
@@ -372,10 +378,10 @@
           
         </div>
       <div id="imgWrap" class="img-wrap">
-        <img id="img" alt="Gráfico de la red">
+        <div id="network"></div>
       </div>
-    
-    
+      <div id="nodeInfo"></div>
+
     <div class="zoom-toolbar">
       <button id="zoomIn" title="Acercar">＋</button>
       <button id="zoomOut" title="Alejar">－</button>


### PR DESCRIPTION
## Summary
- expose graph data with nodes and edges from backend alongside existing PNG
- render interactive network in frontend using vis-network and show node details on click
- allow relation type filtering without server roundtrip

## Testing
- `python -m py_compile app.py modelo_red.py`
- `node --check web/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b994615504832cabbbbb9db738a04a